### PR TITLE
fix(covisit): use keyword field for term query

### DIFF
--- a/src/logQueries.ts
+++ b/src/logQueries.ts
@@ -11,12 +11,12 @@ const LogQueries = (esClient: Client, index: string) => {
           must: [
             {
               term: {
-                reportType: Covisit.reportType,
+                "reportType.keyword": Covisit.reportType,
               },
             },
             {
               term: {
-                content,
+                "content.keyword": content,
               },
             },
           ],


### PR DESCRIPTION
@see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html

fix #111