### PR TITLE
feat: query monolog

### DIFF
--- a/src/logQueries.ts
+++ b/src/logQueries.ts
@@ -11,12 +11,12 @@ const LogQueries = (esClient: Client, index: string) => {
           must: [
             {
               term: {
-                "reportType.keyword": Covisit.reportType,
+                reportType: Covisit.reportType,
               },
             },
             {
               term: {
-                "content.keyword": content,
+                content,
               },
             },
           ],


### PR DESCRIPTION
Il y avait un problème sur la query. On a specifié un mapping specifique, du coup le champ `reportType` est un `keyword`

```
 reportType: {
      type: "keyword",
    }
```